### PR TITLE
Add github workflow to auto run code coverage

### DIFF
--- a/.github/workflow/know_code_coverage.yml
+++ b/.github/workflow/know_code_coverage.yml
@@ -1,0 +1,25 @@
+on: pull_request
+
+name: Continuous Integration
+
+jobs:
+  coverage_report:
+    name: Generate coverage report
+    needs: testing
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout cods
+      uses: actions/checkout@v2
+    - name: Compile
+      uses: make CFLAGS=--coverage
+    - name: Collect Coverage
+      uses: geninfo ./ -b ./ -o ./coverage/lcov.info
+    - name: Report code coverage
+      uses: zgosalvez/github-actions-report-lcov@v3
+      with:
+        coverage-files: ./coverage/lcov.info
+        minimum-coverage: 60
+        artifact-name: code-coverage-report
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: ./
+        update-comment: true


### PR DESCRIPTION
Try a trigger action to replicate following github:

    $ make clean
    $ make CFLAGS=--coverage
    $ geninfo ./ -b ./ -o ./coverage/lcov.info
    $ genhtml lcov.info -o ./coverage