### PR TITLE
Add makefile rule to code coverage in html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,16 @@ CFLAGS += -I./
 $(target): $(objects)
 	$(CC) $^ $(CFLAGS) $(LDFLAGS) -o $@
 
+cov: clean
+	make CFLAGS=--coverage
+	./$(target)
+	geninfo ./ -b ./ -o lcov.info
+	genhtml lcov.info -o ./coverage
+	@ echo "\nopen ./coverage/index.html in browser"
+
 clean:
-	- rm *.o $(target)
+	- $(RM) *.o $(target) *.gcda *.gcno *.gcov lcov.info
+	- $(RM) -r coverage
 
 # $< to consider one dependancy at a time, whereas $^ for all at once.
 # $@ is for target

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Every client code must end by calling deinit() which frees the resources allocat
 
 1. Currently tested on Linux based OS.
 2. Needs 'make' and 'gcc' commands to compile (sudo apt-get install build-essential).
+3. Needs 'lcov' installation for 'geninfo' and 'genhtml' commands (sudo apt-get install lcov)
 
 #### usage
 
@@ -87,3 +88,5 @@ Every client code must end by calling deinit() which frees the resources allocat
 	volume(L)	pressure(Pa)	temperature(K)
 	10.000 L	  101333 Pa	        300 K
 
+	$ make cov      # for coverage report generation
+	                # to also html report generated under ./coverage/index.html can be view


### PR DESCRIPTION
Dependancy: needs lcov installation for geninfo and genhtml commands.
Updated the README.md file for generation of coverage report.
Refer Makefile for command level details for generating coverage reports.