### PR TITLE
Update the nodejs from 16 to 20 by action checkout

### DIFF
--- a/.github/workflows/know_code_coverage.yml
+++ b/.github/workflows/know_code_coverage.yml
@@ -9,11 +9,11 @@ name: Code Coverage
 
 jobs:
   coverage_report:
-    name: Generate coverage report
+    name: Coverage report
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout cods
-      uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Compile
       run: make CFLAGS=--coverage
     - name: Create gcda files by program execution


### PR DESCRIPTION
In github workflow update the action checkout version from v2 to v4 since the Node.js 16 actions are deprecated by github.

Also the name of workflow job "Coverage report" suits better than "Generate Coverage report" at github button for viewing the job's logs.