### PR TITLE
Add workdone piston weight and remove volume input to isothermal process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 CC = gcc
+LDLIBS += -lm
 
 objects := $(patsubst %.c,%.o,$(wildcard *.c))
 target = thermodyn_cycle
@@ -10,7 +11,7 @@ CFLAGS += -I./
 	$(CC) $< -c $(CFLAGS) -o $@
 
 $(target): $(objects)
-	$(CC) $^ $(CFLAGS) $(LDFLAGS) -o $@
+	$(CC) $^ $(CFLAGS) $(LDFLAGS) -o $@ $(LDLIBS)
 
 cov: clean
 	make CFLAGS=--coverage

--- a/thermodyn_client.c
+++ b/thermodyn_client.c
@@ -2,7 +2,8 @@
  * This is a simple test code to check the thermodyn library.
  */
 #include <stdio.h>
-#include <stdlib.h>
+#include <stdlib.h> // atoi()
+#include <math.h>   // NAN
 #include "thermodyn_helper.h"
 
 #define GAS_VOLUME		0.01
@@ -12,10 +13,10 @@
 int main(int argc, char **argv) {
 
 	int iterations = 1;
-	if(argc == 2)
-	{
+	if(argc == 2) {
 		iterations = atoi(argv[1]);
 	}
+
 	/**
 	 * The 'device' type is an opaque pointer,
 	 * followed by init() and uninit() act as interface using the opaque pointer.
@@ -26,35 +27,40 @@ int main(int argc, char **argv) {
 	printf("# At initial state\n");
 	print_current_state(gas);
 
-	for(int i = 0; i < iterations; ++i)
-	{
+	double pressure = get_pressure(gas);
+	double coefficient = 1.2;
+
+	for(int i = 0; i < iterations; ++i) {
 
 	/**
 	 * Isometric heat addition from external source
 	 */
-	update_pressure_isometric(gas, GAS_PRESSURE * 1.2);
+	pressure = get_pressure(gas);
+	update_pressure_isometric(gas, pressure * coefficient);
 	printf("# After increasing pressure for about 20%%\n");
 	print_current_state(gas);
 
 	/**
 	 * Isothermal expansion by heat observed from external source
 	 */
-	update_volume_isothermal(gas, GAS_VOLUME * 1.2);
-	printf("# After increasing volume from 0.01 m³ to 0.012 m³\n");
+	update_volume_isothermal(gas, NAN);
+	/** TODO: NAN is added since client can't set volume. Also library's interface change is restricted */
+	printf("# After letting gas to increase its volume as per isothermal expansion\n");
 	print_current_state(gas);
 
 	/**
 	 * Isometric heat rejection
 	 */
-	update_pressure_isometric(gas, GAS_PRESSURE * 0.8334);
+	pressure = get_pressure(gas);
+	update_pressure_isometric(gas, pressure / coefficient);
 	printf("# After decreasing pressure below original one\n");
 	print_current_state(gas);
 
 	/**
 	 * Isothermal compression by rejecting heat
 	 */
-	update_volume_isothermal(gas, GAS_VOLUME * 0.8334);
-	printf("# After decreasing volume back from 0.012 m³ to 0.01 m³\n");
+	update_volume_isothermal(gas, NAN);
+	printf("# After letting gas to decrease its volume as per isothermal contraction\n");
 	print_current_state(gas);
 
 	}

--- a/thermodyn_helper.c
+++ b/thermodyn_helper.c
@@ -5,28 +5,31 @@
 
 #include <stdio.h>
 #include <stdlib.h> // For: malloc() & free()
-#include <math.h>   // For: fabs()
+#include <math.h>   // For: fabs() & NAN
 #include "thermodyn_helper.h"
+
+#define U_GAS_CONSTANT 8.3144598    /* J/(mol.K) ; where J -> Newton.meter */
 
 /**
  * Definition of opaque pointer 'device' declared in header file
  */
 struct system_t {			/* SI units are used */
-	double volume;			/* liter */
-	double pressure;		/* pascal (or) newton/meter square */
+	double volume;			/* meter cube */
+	double pressure;		/* pascal (or) newton per meter square */
 	double temperature;		/* kelvin */
-	/* moles */
+	double moles;
 	double time;			/* second */
 	double surface_area;
 	double piston_mass;
 	double chamber_length;
+	double workdone;
 };
 typedef struct system_t * device;
 
 /**
- * Static functions declations:
+ * Static functions declaration:
  */
-static double compute_time(device gas, double new_pressure, double new_volume);
+static double compute_time(device gas, double *new_pressure, double *new_volume);
 
 /**
  * Definition of interfaces whose declaration from header file starts here:
@@ -42,10 +45,12 @@ status init(device *gas, double volume, double pressure, double temperature) {
 	(*gas)->volume = volume;
 	(*gas)->pressure = pressure;
 	(*gas)->temperature = temperature;
+	(*gas)->moles = (pressure * volume)/(U_GAS_CONSTANT * temperature);
 	(*gas)->time = 0.0;
 	(*gas)->surface_area = 0.04;
 	(*gas)->piston_mass = 1;
-	(*gas)->chamber_length = 0.25;
+	(*gas)->chamber_length = volume/(*gas)->surface_area;
+	(*gas)->workdone = 0.0;
 	return SUCCESS;
 }
 
@@ -56,9 +61,9 @@ status deinit(device gas) {
 
 // Type 2: Display functions
 status print_current_state(device gas) {
-	printf("volume(L)\t" "pressure(Pa)\t" "temperature(K)\t"  "time(s)\n");
-	printf("%6.3lf L\t"    "%8.0lf Pa\t"      "%11.0lf K\t"  "%.3lf s\n",
-			gas->volume, gas->pressure, gas->temperature, gas->time);
+	printf("volume(m³)\t" "pressure(Pa)\t" "temperature(K)\t"  "time(s)\t" "workdone(J)\n");
+	printf("%6.4lf m³\t"    "%8.0lf Pa\t"      "%11.0lf K\t"  "%.3lf s\t"    "%.3lf (J)\n",
+			gas->volume, gas->pressure, gas->temperature, gas->time, gas->workdone);
 	return SUCCESS;
 }
 
@@ -76,7 +81,7 @@ status update_pressure_isometric(device gas, double new_pressure) {
 	return SUCCESS;
 }
 
-status update_volume_isothermal(device gas, double new_volume) {
+status update_volume_isothermal(device gas, double new_volume) { // TODO: new_volume argument not supported
 	/**
 	 * For Isothermal process, the 'polytropic index' n = 1;
 	 * So the actual relation:
@@ -86,34 +91,70 @@ status update_volume_isothermal(device gas, double new_volume) {
 	 *
 	 * Boyle's Law: P ∝ (1/V)  =>  P1.V1 = P2.V2
 	 */
-	double new_pressure = (gas->volume * gas->pressure) / new_volume;
-	gas->time += compute_time(gas, new_pressure, new_volume);
+	double new_pressure = 101325;
+	if(isnan(new_volume)) {
+		new_volume = (new_pressure * gas->volume) / gas->pressure;
+	} else {
+		new_pressure = (gas->volume * gas->pressure) / new_volume;
+	}
+
+	gas->time += compute_time(gas, &new_pressure, &new_volume);
+	if(new_volume > gas->volume)
+		gas->workdone += U_GAS_CONSTANT * gas->moles * gas->temperature * (log(new_volume/gas->volume));
+	else
+		gas->workdone += U_GAS_CONSTANT * gas->moles * gas->temperature * (log(gas->volume/new_volume));
+
 	gas->volume = new_volume;
 	gas->pressure = new_pressure;
 	return SUCCESS;
 }
 
-// Type 4: Local/Static functions
-double compute_time(device gas, double final_pressure, double final_volume) {
-	double time = 0;
-	double time_step_size = 0.001;
+// Type 4: Get device characteristics functions
+
+double get_pressure(const device gas) {
+	return gas->pressure;
+}
+
+// Type 5: Local/Static functions
+double compute_time(device gas, double *final_pressure, double *final_volume) {
+	double time_step_size = 0.0001;
+	double time = time_step_size;
 	double pressure = gas->pressure;
 	double volume = gas->volume;
 	device piston = gas;
 	double chamber_length = gas->chamber_length;
 	const double pressure_volume_constant = pressure * volume;
+	double velocity = 0.0; // initial velocity assumed zero
+	int previous_direction = 0;
+	int direction = 0;
+	double pressure_steps = 0.01;
 
-	for(;fabs(pressure-final_pressure) > 1.0;
-			time += time_step_size) {
-		double acceleration = ((pressure - final_pressure) * piston->surface_area)
+	do {
+		/**
+		 * The actual formula for acceleration is: a = P_difference * Area
+		 * Since the pressure increases over time and not instant:
+		 */
+		double acceleration = ((pressure - *final_pressure) * pressure_steps * piston->surface_area)
 			/ piston->piston_mass;
+		if(pressure_steps <= 0.99) {
+			pressure_steps += 0.01;
+		}
 		/**
 		 * Assuming uniform acceleration over short interval 'time_step_size'
 		 */
-		chamber_length += (0.5 * acceleration * time_step_size * time_step_size);
+		chamber_length += (velocity * time_step_size)
+			+ (0.5 * acceleration * time_step_size * time_step_size);
+		previous_direction = (velocity > 0.0) ? 1 : ((velocity < 0.0) ? -1 : 0);
+		velocity += acceleration * time_step_size;
+		direction = (velocity > 0.0) ? 1 : ((velocity < 0.0) ? -1 : 0);
 		volume = chamber_length * piston->surface_area;
 		pressure = pressure_volume_constant / volume;
-	}
+		time += time_step_size;
+	} while (0 == previous_direction || previous_direction == direction);
+
 	gas->chamber_length = chamber_length;
+	*final_volume = volume;
+	*final_pressure = pressure;
 	return time;
 }
+

--- a/thermodyn_helper.h
+++ b/thermodyn_helper.h
@@ -27,4 +27,7 @@ status print_current_state(device gas);
 status update_volume_isothermal(device gas, double new_volume);
 status update_pressure_isometric(device gas, double new_pressure);
 
+// Type 4: Get device characteristics functions
+double get_pressure(const device gas);
+
 #endif /* __THERMODYN_HELPER_H__ */


### PR DESCRIPTION
1. Update Makefile to support math.h specific(log()) shared library.
2. Update client/test code to use current pressure instead of hardcode.
3. Remove the logic of passing final volume for isothermal process.
4. Instead use the STP's pressure, assume inside pressure equalize.
5. Add logic to calculate work done by isothermal process.
6. Add logic to account piston weight(inertia), laws to motion, etc.
7. Assuming there is no friction and no flywheel attached.