### PR TITLE
Adds rpm calculation to the test code

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ By default the test code will run one cycle, prints the results and exit.
 	volume(m³)	pressure(Pa)	temperature(K)	time(s)	workdone(J)
 	0.0069 m³	  147746 Pa	        300 K	0.062 s	1151.135 (J)
 
+Change the test code to keep a note of start and end time to compute rpm
+(Revolutions per minute). The test code is a right place to keep track of
+start and end time of a thermodynamic cycle and library is not a good place.
+Because for that to happen, library will need to know about the cycles ran
+from test codes perspective or additional overhead and assumptions
+needed about thermodynamic processes. Coming back to printing the rpm,
+first filter out other details accept rpm as follows:
+
+	$ ./thermodyn_cycle 10 | grep -e "^# Rota"
+	# Rotational Speed = 967.742 rmp at cycle = 1
+	# Rotational Speed = 960.000 rmp at cycle = 2
+	# Rotational Speed = 952.381 rmp at cycle = 3
+	# Rotational Speed = 946.372 rmp at cycle = 4
+	# Rotational Speed = 943.396 rmp at cycle = 5
+	# Rotational Speed = 941.915 rmp at cycle = 6
+	# Rotational Speed = 940.439 rmp at cycle = 7
+	# Rotational Speed = 940.439 rmp at cycle = 8
+	# Rotational Speed = 940.439 rmp at cycle = 9
+	# Rotational Speed = 940.439 rmp at cycle = 10
+
 Further we can check the code coverage using following make target `cov`.
 
 	$ make cov      # for coverage report generation

--- a/thermodyn_client.c
+++ b/thermodyn_client.c
@@ -38,6 +38,7 @@ int main(int argc, char **argv) {
 
 	for(int i = 0; i < iterations; ++i) {
 
+		double start_time = get_time(gas);
 		/**
 		 * Isometric heat addition from external source
 		 */
@@ -69,6 +70,8 @@ int main(int argc, char **argv) {
 		update_volume_isothermal(gas, NAN);
 		printf("# After letting gas to decrease its volume as per isothermal contraction\n");
 		print_current_state_value(gas);
+		double end_time = get_time(gas);
+		printf("# Rotational Speed = %.3lf rmp at cycle = %d \n", 60/(end_time - start_time), i+1);
 	}
 
 	deinit(gas);

--- a/thermodyn_helper.c
+++ b/thermodyn_helper.c
@@ -122,6 +122,10 @@ double get_pressure(const device gas) {
 	return gas->pressure;
 }
 
+double get_time(const device piston) {
+	return piston->time;
+}
+
 // Type 5: Local/Static functions
 double compute_time(device gas, double *final_pressure, double *final_volume) {
 	double time_step_size = 0.0001;

--- a/thermodyn_helper.h
+++ b/thermodyn_helper.h
@@ -30,5 +30,6 @@ status update_pressure_isometric(device gas, double new_pressure);
 
 // Type 4: Get device characteristics functions
 double get_pressure(const device gas);
+double get_time(const device piston);
 
 #endif /* __THERMODYN_HELPER_H__ */


### PR DESCRIPTION
Adds get_time() like interface to library so that test will keep a track of start and end time of a cycle.
This start and end time for each cycle will be used to calculate rpm.