### PR TITLE
Updates lib functions to ignore volume changes

### DIFF
--- a/thermodyn_helper.c
+++ b/thermodyn_helper.c
@@ -88,7 +88,7 @@ status update_pressure_isometric(device gas, double new_pressure) {
 	return SUCCESS;
 }
 
-status update_volume_isothermal(device gas, double new_volume) { // TODO: new_volume argument not supported
+status update_volume_isothermal(device gas, double) {
 	/**
 	 * For Isothermal process, the 'polytropic index' n = 1;
 	 * So the actual relation:
@@ -99,11 +99,7 @@ status update_volume_isothermal(device gas, double new_volume) { // TODO: new_vo
 	 * Boyle's Law: P ∝ (1/V)  =>  P1.V1 = P2.V2
 	 */
 	double new_pressure = EQUILIBRIUM_PRESSURE;
-	if(isnan(new_volume)) {
-		new_volume = (new_pressure * gas->volume) / gas->pressure;
-	} else {
-		new_pressure = (gas->volume * gas->pressure) / new_volume;
-	}
+	double new_volume = (new_pressure * gas->volume) / gas->pressure;
 
 	gas->time += compute_time(gas, &new_pressure, &new_volume);
 	if(new_volume > gas->volume)


### PR DESCRIPTION
Earlier implementation of update_volume_isothermal() was making use of new volume as input till which the gas expands.
But this assumption wasn't making sense, I updated the client code send NAN and ignore it on the library side if NAN is received. This ignoring part of code become a dead code and hence not testable or the code coverage got reduced.

Fix: the current code change will ignore volume argument of update_volume_isothermal() and hence dead code part can be removed.