### PR TITLE
Add ways to set initial value of vol pressure temp

### DIFF
--- a/thermodyn_client.c
+++ b/thermodyn_client.c
@@ -12,9 +12,15 @@
 #include <math.h>   // NAN
 #include "thermodyn_helper.h"
 
-#define GAS_VOLUME		0.01
-#define GAS_PRESSURE	101325
-#define GAS_TEMPERATURE	300
+#ifndef GAS_VOLUME
+#  define GAS_VOLUME        0.01
+#endif
+#ifndef GAS_PRESSURE
+#  define GAS_PRESSURE      101325
+#endif
+#ifndef GAS_TEMPERATURE
+#  define GAS_TEMPERATURE   300
+#endif
 
 int main(int argc, char **argv) {
 


### PR DESCRIPTION
First run make clean to start with custom initial values.
We can set the initial volume gas using GAS_VOLUME:
`make CFLAGS=-DGAS_VOLUME=0.02`

Similarly, initial pressure and temperature
can be set using `GAS_PRESSURE` and `GAS_TEMPERATURE`.
Earlier, if no initial values are set, then default values are as follows:
GAS_VOLUME=0.01 m<sup>3</sup>
GAS_PRESSURE=101325 Pa
GAS_TEMPERATURE=300 K